### PR TITLE
install to ~/.local/bin by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ REPO_OWNER="ibigio"
 REPO_NAME="shell-ai"
 TOOL_NAME="shell-ai"
 TOOL_SYMLINK="q"
+INSTALL_DIR="$HOME/.local/bin"
 
 # Detect the platform (architecture and OS)
 ARCH="$(uname -m)"
@@ -25,8 +26,8 @@ mkdir -p "${TOOL_NAME}-temp"
 tar xzf "${TOOL_NAME}.tar.gz" -C "${TOOL_NAME}-temp"
 
 # Make the binary executable
-mv "${TOOL_NAME}-temp/${TOOL_NAME}" "/usr/local/bin/${TOOL_SYMLINK}"
-chmod +x /usr/local/bin/"${TOOL_SYMLINK}"
+mv "${TOOL_NAME}-temp/${TOOL_NAME}" "${INSTALL_DIR}/${TOOL_SYMLINK}"
+chmod +x "${INSTALL_DIR}"/"${TOOL_SYMLINK}"
 
 # # Clean up
 rm -rf "${TOOL_NAME}-temp"


### PR DESCRIPTION
`/usr/local/bin` is usually only writable by root, which means not everyone can install there (if, for example, someone's on a shared machine). The install dir could also an argument to the script too (with some sane default value). 