### PR TITLE
Configuration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ preferences:
 models:
   - name: gpt-4-1106-preview
     endpoint: https://api.openai.com/v1/chat/completions
-    auth_env_var: OPENAI_API_KEY
-    org_env_var: OPENAI_ORG_ID
+    api_key: ${OPENAI_API_KEY}
+    org_id: ${OPENAI_ORG_ID}
+    project_id: ${OPENAI_PROJECT_ID}
     prompt:
       [
         {
@@ -141,7 +142,7 @@ models:
 config_format_version: "1"
 ````
 
-**Note:** The `auth_env_var` is set to `OPENAI_API_KEY` verbatim, not the key itself, so as to not keep sensitive information in the config file.
+**Note:** The `api_key` references an environment variable by default, not the key itself.
 
 ### Setting Up a Local Model
 
@@ -163,8 +164,9 @@ Here's what I did:
 models:
   - name: stablelm-zephyr-3b.Q8_0
     endpoint: http://127.0.0.1:8080/v1/chat/completions
-    auth_env_var: OPENAI_API_KEY
-    org_env_var: OPENAI_ORG_ID
+    api_key: ${OPENAI_API_KEY}
+    org_id: ${OPENAI_ORG_ID}
+    project_id: ${OPENAI_PROJECT_ID}
     prompt:
       - role: system
         content:
@@ -212,7 +214,7 @@ Define `AZURE_OPENAI_API_KEY` environment variable and make few changes to the c
 models:
   - name: azure-gpt-4
     endpoint: https://<resource_name>.openai.azure.com/openai/deployments/<deployment_name>/chat/completions?api-version=<api_version>
-    auth_env_var: AZURE_OPENAI_API_KEY
+    api_key: ${AZURE_OPENAI_API_KEY}
 ```
 
 ### I Fucked Up The Config File

--- a/config/cli.go
+++ b/config/cli.go
@@ -399,10 +399,7 @@ func modelDetailsForModelMenu(appConfig AppConfig, modelConfig types.ModelConfig
 			title: "Endpoint: " + modelConfig.Endpoint,
 		},
 		{
-			title: "Auth: " + modelConfig.Auth,
-		},
-		{
-			title: "Auth: " + modelConfig.Auth,
+			title: "Auth: " + modelConfig.ApiKey.Raw(),
 		},
 		{
 			title: "Prompt",

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,12 @@ func loadExistingConfig(filePath string) (AppConfig, error) {
 	if err != nil {
 		return config, fmt.Errorf("error unmarshalling config file: %s", err)
 	}
+	if config.Version == "1" {
+		for i, modelCfg := range config.Models {
+			config.Models[i] = modelCfg.Migrate()
+		}
+		config.Version = "2"
+	}
 	return config, nil
 }
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,7 @@ models:
     endpoint: https://api.openai.com/v1/chat/completions
     auth_env_var: OPENAI_API_KEY
     org_env_var: OPENAI_ORG_ID
+    project_env_var: OPENAI_PROJECT_ID
     prompt:
       [
         {
@@ -20,6 +21,7 @@ models:
     endpoint: https://api.openai.com/v1/chat/completions
     auth_env_var: OPENAI_API_KEY
     org_env_var: OPENAI_ORG_ID
+    project_env_var: OPENAI_PROJECT_ID
     prompt:
       [
         {
@@ -34,6 +36,7 @@ models:
     endpoint: https://api.openai.com/v1/chat/completions
     auth_env_var: OPENAI_API_KEY
     org_env_var: OPENAI_ORG_ID
+    project_env_var: OPENAI_PROJECT_ID
     prompt:
       [
         {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,9 +4,9 @@ preferences:
 models:
   - name: gpt-4
     endpoint: https://api.openai.com/v1/chat/completions
-    auth_env_var: OPENAI_API_KEY
-    org_env_var: OPENAI_ORG_ID
-    project_env_var: OPENAI_PROJECT_ID
+    api_key: ${OPENAI_API_KEY}
+    org_id: ${OPENAI_ORG_ID}
+    project_id: ${OPENAI_PROJECT_ID}
     prompt:
       [
         {
@@ -19,9 +19,9 @@ models:
 
   - name: gpt-4-1106-preview
     endpoint: https://api.openai.com/v1/chat/completions
-    auth_env_var: OPENAI_API_KEY
-    org_env_var: OPENAI_ORG_ID
-    project_env_var: OPENAI_PROJECT_ID
+    api_key: ${OPENAI_API_KEY}
+    org_id: ${OPENAI_ORG_ID}
+    project_id: ${OPENAI_PROJECT_ID}
     prompt:
       [
         {
@@ -34,9 +34,9 @@ models:
 
   - name: gpt-3.5-turbo
     endpoint: https://api.openai.com/v1/chat/completions
-    auth_env_var: OPENAI_API_KEY
-    org_env_var: OPENAI_ORG_ID
-    project_env_var: OPENAI_PROJECT_ID
+    api_key: ${OPENAI_API_KEY}
+    org_id: ${OPENAI_ORG_ID}
+    project_id: ${OPENAI_PROJECT_ID}
     prompt:
       [
         {
@@ -52,4 +52,4 @@ models:
         { role: "assistant", content: "```bash\necho \"hi\"\n```" },
       ]
 
-config_format_version: "1"
+config_format_version: "2"

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -48,6 +48,9 @@ func (c *LLMClient) createRequest(payload Payload) (*http.Request, error) {
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)
 	}
+	if c.config.ProjectID != "" {
+		req.Header.Set("OpenAI-Project", c.config.ProjectID)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	return req, nil
 }

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -40,16 +40,19 @@ func (c *LLMClient) createRequest(payload Payload) (*http.Request, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	apiKey := c.config.ApiKey.Resolve()
 	if strings.Contains(c.config.Endpoint, "openai.azure.com") {
-		req.Header.Set("Api-Key", c.config.Auth)
+		req.Header.Set("Api-Key", apiKey)
 	} else {
-		req.Header.Set("Authorization", "Bearer "+c.config.Auth)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
-	if c.config.OrgID != "" {
-		req.Header.Set("OpenAI-Organization", c.config.OrgID)
+	orgID := c.config.OrgID.Resolve()
+	if orgID != "" {
+		req.Header.Set("OpenAI-Organization", orgID)
 	}
-	if c.config.ProjectID != "" {
-		req.Header.Set("OpenAI-Project", c.config.ProjectID)
+	projectID := c.config.ProjectID.Resolve()
+	if projectID != "" {
+		req.Header.Set("OpenAI-Project", projectID)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return req, nil

--- a/types/types.go
+++ b/types/types.go
@@ -5,6 +5,7 @@ type ModelConfig struct {
 	Endpoint  string    `yaml:"endpoint"`
 	Auth      string    `yaml:"auth_env_var"`
 	OrgID     string    `yaml:"org_env_var,omitempty"`
+	ProjectID string    `yaml:"project_env_var,omitempty"`
 	Prompt    []Message `yaml:"prompt"`
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -1,12 +1,43 @@
 package types
 
+import (
+	"fmt"
+	"os"
+)
+
+type ValueOrVar string
+
+func (v ValueOrVar) Raw() string {
+	return string(v)
+}
+
+func (v ValueOrVar) Resolve() string {
+	return os.ExpandEnv(string(v))
+}
+
 type ModelConfig struct {
-	ModelName string    `yaml:"name"`
-	Endpoint  string    `yaml:"endpoint"`
-	Auth      string    `yaml:"auth_env_var"`
-	OrgID     string    `yaml:"org_env_var,omitempty"`
-	ProjectID string    `yaml:"project_env_var,omitempty"`
-	Prompt    []Message `yaml:"prompt"`
+	ModelName string     `yaml:"name"`
+	Endpoint  string     `yaml:"endpoint"`
+	ApiKey    ValueOrVar `yaml:"api_key,omitempty"`
+	OrgID     ValueOrVar `yaml:"org_id,omitempty"`
+	ProjectID ValueOrVar `yaml:"project_id,omitempty"`
+	Prompt    []Message  `yaml:"prompt"`
+	// deprecated var-only keys
+	V1_Auth      string `yaml:"auth_env_var,omitempty"`
+	V1_OrgID     string `yaml:"org_env_var,omitempty"`
+	V1_ProjectID string `yaml:"project_env_var,omitempty"`
+}
+
+func (c ModelConfig) Migrate() ModelConfig {
+	c.ApiKey = ValueOrVar(fmt.Sprintf("${%s}", c.V1_Auth))
+	c.V1_Auth = ""
+
+	c.OrgID = ValueOrVar(fmt.Sprintf("${%s}", c.V1_OrgID))
+	c.V1_OrgID = ""
+
+	c.ProjectID = ValueOrVar("${OPENAI_PROJECT_ID}")
+
+	return c
 }
 
 type Message struct {


### PR DESCRIPTION
### What?

- Support inline values in config files
- Make usage of env vars obvious and explicit
- Do it in a backwards compatible manner

### Why?

Environment is not always ideal for keeping secrets. For code that gets deployed on servers or in containers - obviously. But this tool will running on the users personal device in almost all cases. Env vars are much more exposed to 3rd parties and can be read by anything executed from your shell or its forks. That includes random postinstall scripts in that 10GB `node_modules` folder.

There are workarounds, like aliasing the `q` command to `export ... && q`, but supporting inline config and making env usage explicit is still an improvement. Inline config would be a better default, but for now I just wanted to add flexibility without breaking backwards compatibility.